### PR TITLE
feat(OverlayView): Added new pixelPositionOffset prop

### DIFF
--- a/docs/build/bundle.9767a103.js
+++ b/docs/build/bundle.9767a103.js
@@ -37525,7 +37525,7 @@
       {
         type: "code",
         content:
-          'const { compose, withProps, withStateHandlers } = require("recompose");\nconst FaAnchor = require("react-icons/lib/fa/anchor");\nconst {\n  withScriptjs,\n  withGoogleMap,\n  GoogleMap,\n  OverlayView,\n} = require("@syncromatics/react-google-maps");\n\nconst getPixelPositionOffset = (width, height) => ({\n  x: -(width / 2),\n  y: -(height / 2),\n})\n\nconst MapWithAnOverlayView = compose(\n  withStateHandlers(() => ({\n    count: 0,\n  }), {\n    onClick: ({ count }) => () => ({\n      count: count + 1,\n    })\n  }),\n  withScriptjs,\n  withGoogleMap\n)(props =>\n  <GoogleMap\n    defaultZoom={8}\n    defaultCenter={{ lat: -34.397, lng: 150.644 }}\n  >\n    <OverlayView\n      position={{ lat: -34.397, lng: 150.644 }}\n      /*\n       * An alternative to specifying position is specifying bounds.\n       * bounds can either be an instance of google.maps.LatLngBounds\n       * or an object in the following format:\n       * bounds={{\n       *    ne: { lat: 62.400471, lng: -150.005608 },\n       *    sw: { lat: 62.281819, lng: -150.287132 }\n       * }}\n       */\n      /*\n       * 1. Specify the pane the OverlayView will be rendered to. For\n       *    mouse interactivity, use `OverlayView.OVERLAY_MOUSE_TARGET`.\n       *    Defaults to `OverlayView.OVERLAY_LAYER`.\n       */\n      mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}\n      /*\n       * 2. Tweak the OverlayView\'s pixel position. In this case, we\'re\n       *    centering the content.\n       */\n      getPixelPositionOffset={getPixelPositionOffset}\n      /*\n       * 3. Create OverlayView content using standard React components.\n       */\n    >\n      <div style={{ background: `white`, border: `1px solid #ccc`, padding: 15 }}>\n        <h1>OverlayView</h1>\n        <button onClick={props.onClick} style={{ height: 60 }}>\n          I have been clicked {props.count} time{props.count > 1 ? `s` : ``}\n        </button>\n      </div>\n    </OverlayView>\n  </GoogleMap>\n);\n\n<MapWithAnOverlayView\n  googleMapURL={GOOGLE_MAP_URL}\n  loadingElement={<div style={{ height: `100%` }} />}\n  containerElement={<div style={{ height: `400px` }} />}\n  mapElement={<div style={{ height: `100%` }} />}\n/>',
+          'const { compose, withProps, withStateHandlers } = require("recompose");\nconst FaAnchor = require("react-icons/lib/fa/anchor");\nconst {\n  withScriptjs,\n  withGoogleMap,\n  GoogleMap,\n  OverlayView,\n} = require("@syncromatics/react-google-maps");\n\nconst getPixelPositionOffset = (width, height) => ({\n  x: -(width / 2),\n  y: -(height / 2),\n})\n\nconst MapWithAnOverlayView = compose(\n  withStateHandlers(() => ({\n    count: 0,\n  }), {\n    onClick: ({ count }) => () => ({\n      count: count + 1,\n    })\n  }),\n  withScriptjs,\n  withGoogleMap\n)(props =>\n  <GoogleMap\n    defaultZoom={8}\n    defaultCenter={{ lat: -34.397, lng: 150.644 }}\n  >\n    <OverlayView\n      position={{ lat: -34.397, lng: 150.644 }}\n      /*\n       * An alternative to specifying position is specifying bounds.\n       * bounds can either be an instance of google.maps.LatLngBounds\n       * or an object in the following format:\n       * bounds={{\n       *    ne: { lat: 62.400471, lng: -150.005608 },\n       *    sw: { lat: 62.281819, lng: -150.287132 }\n       * }}\n       */\n      /*\n       * 1. Specify the pane the OverlayView will be rendered to. For\n       *    mouse interactivity, use `OverlayView.OVERLAY_MOUSE_TARGET`.\n       *    Defaults to `OverlayView.OVERLAY_LAYER`.\n       */\n      mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}\n      /*\n       * 2. Tweak the OverlayView\'s pixel position. In this case, we\'re\n       *    centering the content. Warning, this ultimately causes the browser\n       *    to render/reflow. If you can use a fixed pixel position offset, use\n       *    the pixelPositionOffset prop instead:\n       * \n       *    pixelPositionOffset={{ x: 10, y: 20 }}\n       */\n      getPixelPositionOffset={getPixelPositionOffset}\n      /*\n       * 3. Create OverlayView content using standard React components.\n       */\n    >\n      <div style={{ background: `white`, border: `1px solid #ccc`, padding: 15 }}>\n        <h1>OverlayView</h1>\n        <button onClick={props.onClick} style={{ height: 60 }}>\n          I have been clicked {props.count} time{props.count > 1 ? `s` : ``}\n        </button>\n      </div>\n    </OverlayView>\n  </GoogleMap>\n);\n\n<MapWithAnOverlayView\n  googleMapURL={GOOGLE_MAP_URL}\n  loadingElement={<div style={{ height: `100%` }} />}\n  containerElement={<div style={{ height: `400px` }} />}\n  mapElement={<div style={{ height: `100%` }} />}\n/>',
         settings: {},
         evalInContext: s,
       },
@@ -39741,6 +39741,26 @@
         },
         getPixelPositionOffset: {
           type: { name: "func" },
+          required: !1,
+          description: "",
+          tags: {
+            see: [
+              {
+                title: "see",
+                description:
+                  "https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView",
+              },
+            ],
+          },
+        },
+        pixelPositionOffset: {
+          type: {
+            name: "shape",
+            value: {
+              x: { name: "number", required: !1 },
+              y: { name: "number", required: !1 },
+            },
+          },
           required: !1,
           description: "",
           tags: {
@@ -46283,22 +46303,25 @@
             throw new TypeError("Cannot call a class as a function")
         })(this, OverlayView)
         var n = (function _possibleConstructorReturn(e, t) {
-            if (!e)
-              throw new ReferenceError(
-                "this hasn't been initialised - super() hasn't been called"
-              )
-            return !t || ("object" != typeof t && "function" != typeof t)
-              ? e
-              : t
-          })(
-            this,
-            (OverlayView.__proto__ || Object.getPrototypeOf(OverlayView)).call(
-              this,
-              e,
-              t
+          if (!e)
+            throw new ReferenceError(
+              "this hasn't been initialised - super() hasn't been called"
             )
-          ),
-          r = new google.maps.OverlayView()
+          return !t || ("object" != typeof t && "function" != typeof t) ? e : t
+        })(
+          this,
+          (OverlayView.__proto__ || Object.getPrototypeOf(OverlayView)).call(
+            this,
+            e,
+            t
+          )
+        )
+        n.addContainerToPane = function() {
+          var e = n.props.mapPaneName
+          a()(!!e, "OverlayView requires props.mapPaneName but got %s", e)
+          n.state[g.p].getPanes()[e].appendChild(n.containerElement)
+        }
+        var r = new google.maps.OverlayView()
         return (
           (r.onAdd = s.a.bind(n.onAdd, n)),
           (r.draw = s.a.bind(n.draw, n)),
@@ -46315,25 +46338,19 @@
             key: "onAdd",
             value: function onAdd() {
               ;(this.containerElement = document.createElement("div")),
-                (this.containerElement.style.position = "absolute")
+                (this.containerElement.style.position = "absolute"),
+                this.addContainerToPane()
             },
           },
           {
             key: "draw",
             value: function draw() {
-              var e = this.props.mapPaneName
-              a()(
-                !!e,
-                "OverlayView requires either props.mapPaneName or props.defaultMapPaneName but got %s",
-                e
+              d.a.unstable_renderSubtreeIntoContainer(
+                this,
+                u.a.Children.only(this.props.children),
+                this.containerElement,
+                this.onPositionElement
               )
-              this.state[g.p].getPanes()[e].appendChild(this.containerElement),
-                d.a.unstable_renderSubtreeIntoContainer(
-                  this,
-                  u.a.Children.only(this.props.children),
-                  this.containerElement,
-                  this.onPositionElement
-                )
             },
           },
           {
@@ -46368,6 +46385,8 @@
             key: "componentDidUpdate",
             value: function componentDidUpdate(e) {
               Object(f.b)(this, this.state[g.p], _, v, e),
+                e.mapPaneName !== this.props.mapPaneName &&
+                  this.addContainerToPane(),
                 s.a.delay(this.state[g.p].draw)
             },
           },
@@ -46416,6 +46435,7 @@
         bounds: h.a.object,
         children: h.a.node.isRequired,
         getPixelPositionOffset: h.a.func,
+        pixelPositionOffset: h.a.shape({ x: h.a.number, y: h.a.number }),
       }),
       (b.contextTypes = ((r = {}),
       _defineProperty(r, g.l, h.a.object),
@@ -49282,8 +49302,9 @@
   "./src/utils/OverlayViewHelper.js": function(e, t, n) {
     "use strict"
     ;(t.b = function getOffsetOverride(e, t) {
-      var n = t.getPixelPositionOffset
-      return o.a.isFunction(n) ? n(e.offsetWidth, e.offsetHeight) : {}
+      var n = t.getPixelPositionOffset,
+        r = t.pixelPositionOffset
+      return r || (o.a.isFunction(n) ? n(e.offsetWidth, e.offsetHeight) : {})
     }),
       (t.a = function getLayoutStyles(e, t, n) {
         if (n.bounds) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,5 +7,5 @@
 	</head>
 	<body>
 		<div id="app"></div>
-	<script type="text/javascript" src="build/bundle.b3fa57a1.js"></script></body>
+	<script type="text/javascript" src="build/bundle.9767a103.js"></script></body>
 </html>

--- a/lib/components/OverlayView.js
+++ b/lib/components/OverlayView.js
@@ -102,6 +102,20 @@ var OverlayView = (exports.OverlayView = (function(_React$PureComponent) {
       ).call(this, props, context)
     )
 
+    _this.addContainerToPane = function() {
+      var mapPaneName = _this.props.mapPaneName
+
+      ;(0, _invariant2.default)(
+        !!mapPaneName,
+        "OverlayView requires props.mapPaneName but got %s",
+        mapPaneName
+      )
+
+      // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
+      var mapPanes = _this.state[_constants.OVERLAY_VIEW].getPanes()
+      mapPanes[mapPaneName].appendChild(_this.containerElement)
+    }
+
     var overlayView = new google.maps.OverlayView()
     // You must implement three methods: onAdd(), draw(), and onRemove().
     overlayView.onAdd = (0, _bind3.default)(_this.onAdd, _this)
@@ -128,22 +142,12 @@ var OverlayView = (exports.OverlayView = (function(_React$PureComponent) {
       value: function onAdd() {
         this.containerElement = document.createElement("div")
         this.containerElement.style.position = "absolute"
+        this.addContainerToPane()
       },
     },
     {
       key: "draw",
       value: function draw() {
-        var mapPaneName = this.props.mapPaneName
-
-        ;(0, _invariant2.default)(
-          !!mapPaneName,
-          "OverlayView requires either props.mapPaneName or props.defaultMapPaneName but got %s",
-          mapPaneName
-        )
-        // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
-        var mapPanes = this.state[_constants.OVERLAY_VIEW].getPanes()
-        mapPanes[mapPaneName].appendChild(this.containerElement)
-
         _reactDom2.default.unstable_renderSubtreeIntoContainer(
           this,
           _react2.default.Children.only(this.props.children),
@@ -206,6 +210,9 @@ var OverlayView = (exports.OverlayView = (function(_React$PureComponent) {
           updaterMap,
           prevProps
         )
+        if (prevProps.mapPaneName !== this.props.mapPaneName) {
+          this.addContainerToPane()
+        }
         ;(0, _delay3.default)(this.state[_constants.OVERLAY_VIEW].draw)
       },
     },
@@ -287,6 +294,14 @@ OverlayView.propTypes = {
    * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView
    */
   getPixelPositionOffset: _propTypes2.default.func,
+
+  /**
+   * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView
+   */
+  pixelPositionOffset: _propTypes2.default.shape({
+    x: _propTypes2.default.number,
+    y: _propTypes2.default.number,
+  }),
 }
 OverlayView.contextTypes = ((_OverlayView$contextT = {}),
 (0, _defineProperty3.default)(

--- a/lib/utils/OverlayViewHelper.js
+++ b/lib/utils/OverlayViewHelper.js
@@ -17,13 +17,16 @@ function _interopRequireDefault(obj) {
 
 /* global google */
 function getOffsetOverride(containerElement, props) {
-  var getPixelPositionOffset = props.getPixelPositionOffset
+  var getPixelPositionOffset = props.getPixelPositionOffset,
+    pixelPositionOffset = props.pixelPositionOffset
   //
   // Allows the component to control the visual position of the OverlayView
   // relative to the LatLng pixel position.
   //
 
-  if ((0, _isFunction3.default)(getPixelPositionOffset)) {
+  if (pixelPositionOffset) {
+    return pixelPositionOffset
+  } else if ((0, _isFunction3.default)(getPixelPositionOffset)) {
     return getPixelPositionOffset(
       containerElement.offsetWidth,
       containerElement.offsetHeight

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syncromatics/react-google-maps",
-  "version": "9.8.0-feature-EN-3984-do-not-cause-reflow-unnecessarily.0",
+  "version": "9.8.0-feature-EN-3984-do-not-cause-reflow-unnecessarily.1",
   "description": "React.js Google Maps integration component",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syncromatics/react-google-maps",
-  "version": "9.7.0",
+  "version": "9.8.0-feature-EN-3984-do-not-cause-reflow-unnecessarily.0",
   "description": "React.js Google Maps integration component",
   "license": "MIT",
   "author": {

--- a/src/components/OverlayView.jsx
+++ b/src/components/OverlayView.jsx
@@ -58,6 +58,14 @@ export class OverlayView extends React.PureComponent {
      * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView
      */
     getPixelPositionOffset: PropTypes.func,
+
+    /**
+     * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView
+     */
+    pixelPositionOffset: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+    }),
   }
 
   static contextTypes = {
@@ -84,22 +92,26 @@ export class OverlayView extends React.PureComponent {
     }
   }
 
-  onAdd() {
-    this.containerElement = document.createElement(`div`)
-    this.containerElement.style.position = `absolute`
-  }
-
-  draw() {
+  addContainerToPane = () => {
     const { mapPaneName } = this.props
     invariant(
       !!mapPaneName,
-      `OverlayView requires either props.mapPaneName or props.defaultMapPaneName but got %s`,
+      `OverlayView requires props.mapPaneName but got %s`,
       mapPaneName
     )
+
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
     const mapPanes = this.state[OVERLAY_VIEW].getPanes()
     mapPanes[mapPaneName].appendChild(this.containerElement)
+  }
 
+  onAdd() {
+    this.containerElement = document.createElement(`div`)
+    this.containerElement.style.position = `absolute`
+    this.addContainerToPane()
+  }
+
+  draw() {
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
       React.Children.only(this.props.children),
@@ -143,6 +155,9 @@ export class OverlayView extends React.PureComponent {
       updaterMap,
       prevProps
     )
+    if (prevProps.mapPaneName !== this.props.mapPaneName) {
+      this.addContainerToPane()
+    }
     _.delay(this.state[OVERLAY_VIEW].draw)
   }
 

--- a/src/components/OverlayView.md
+++ b/src/components/OverlayView.md
@@ -49,7 +49,11 @@ const MapWithAnOverlayView = compose(
       mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
       /*
        * 2. Tweak the OverlayView's pixel position. In this case, we're
-       *    centering the content.
+       *    centering the content. Warning, this ultimately causes the browser
+       *    to render/reflow. If you can use a fixed pixel position offset, use
+       *    the pixelPositionOffset prop instead:
+       * 
+       *    pixelPositionOffset={{ x: 10, y: 20 }}
        */
       getPixelPositionOffset={getPixelPositionOffset}
       /*

--- a/src/macros/OverlayView.jsx
+++ b/src/macros/OverlayView.jsx
@@ -55,6 +55,13 @@ export class OverlayView extends React.PureComponent {
      * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView
      */
     getPixelPositionOffset: PropTypes.func,
+    /**
+     * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#OverlayView
+     */
+    pixelPositionOffset: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+    }),
   }
 
   static contextTypes = {
@@ -81,22 +88,26 @@ export class OverlayView extends React.PureComponent {
     }
   }
 
-  onAdd() {
-    this.containerElement = document.createElement(`div`)
-    this.containerElement.style.position = `absolute`
-  }
-
-  draw() {
+  addContainerToPane = () => {
     const { mapPaneName } = this.props
     invariant(
       !!mapPaneName,
-      `OverlayView requires either props.mapPaneName or props.defaultMapPaneName but got %s`,
+      `OverlayView requires props.mapPaneName but got %s`,
       mapPaneName
     )
+
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
     const mapPanes = this.state[OVERLAY_VIEW].getPanes()
     mapPanes[mapPaneName].appendChild(this.containerElement)
+  }
 
+  onAdd() {
+    this.containerElement = document.createElement(`div`)
+    this.containerElement.style.position = `absolute`
+    this.addContainerToPane()
+  }
+
+  draw() {
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
       React.Children.only(this.props.children),
@@ -140,6 +151,9 @@ export class OverlayView extends React.PureComponent {
       updaterMap,
       prevProps
     )
+    if (prevProps.mapPaneName !== this.props.mapPaneName) {
+      this.addContainerToPane()
+    }
     _.delay(this.state[OVERLAY_VIEW].draw)
   }
 

--- a/src/utils/OverlayViewHelper.js
+++ b/src/utils/OverlayViewHelper.js
@@ -2,12 +2,14 @@
 import _ from "lodash"
 
 export function getOffsetOverride(containerElement, props) {
-  const { getPixelPositionOffset } = props
+  const { getPixelPositionOffset, pixelPositionOffset } = props
   //
   // Allows the component to control the visual position of the OverlayView
   // relative to the LatLng pixel position.
   //
-  if (_.isFunction(getPixelPositionOffset)) {
+  if (pixelPositionOffset) {
+    return pixelPositionOffset
+  } else if (_.isFunction(getPixelPositionOffset)) {
     return getPixelPositionOffset(
       containerElement.offsetWidth,
       containerElement.offsetHeight


### PR DESCRIPTION
The new `pixelPositionOffset` prop allows implementers to declaratively specify pixel positions of overlay views if they are known ahead of time. This avoids using `offsetWidth` and `offsetHeight` that are passed in to `getPixelPositionOffset` and which trigger the browser to re-render/reflow elements on the page in order to calculate the width and height.

Closes https://syncromatics.atlassian.net/browse/EN-3984

_Note to reviewers: I will rebase on `master` once the fork branch is merged_